### PR TITLE
Delete .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-DB_NAME='absence_reporting_db'
-DB_USER='root'
-DB_PASSWORD='$100Billion'


### PR DESCRIPTION
The .gitignore file was supposed to ignore the .env file so we could all use our own credentials, but it did not. I am deleting it from the repository.